### PR TITLE
Upgrade membrane_raw_audio_format to 0.11.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RawAudioParser.Mixfile do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.3.0"
   @github_url "https://github.com/membraneframework/membrane_raw_audio_parser_plugin"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule Membrane.RawAudioParser.Mixfile do
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:dialyxir, ">= 0.0.0", only: :dev, runtime: false},
       {:credo, ">= 0.0.0", only: :dev, runtime: false},
-      {:membrane_raw_audio_format, "~> 0.10.0"},
+      {:membrane_raw_audio_format, "~> 0.11.0"},
       {:membrane_file_plugin, "~> 0.13.3", only: :test}
     ]
   end


### PR DESCRIPTION
Upgrades the :membrane_raw_audio_format dependency to 0.11.0